### PR TITLE
feat: add an optional capacity credit parameter to the local session signature generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ async fn main() {
     // Generate session signatures with your wallet (no PKP needed!)
     let expiration = (chrono::Utc::now() + chrono::Duration::minutes(10)).to_rfc3339();
     let session_sigs = client
-        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, None)
+        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, vec![])
         .await
         .expect("Failed to create local session signatures");
 
@@ -291,7 +291,7 @@ let session_sigs = client
         &wallet,
         resource_ability_requests,
         &expiration,
-        None,
+        vec![],
     )
     .await?;
 

--- a/lit-rust-sdk/README.md
+++ b/lit-rust-sdk/README.md
@@ -69,7 +69,7 @@ async fn main() {
 
     let expiration = (chrono::Utc::now() + chrono::Duration::minutes(10)).to_rfc3339();
     let session_sigs = client
-        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, None)
+        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, vec![])
         .await
         .expect("Failed to create session signatures");
 

--- a/lit-rust-sdk/src/client/session_sigs.rs
+++ b/lit-rust-sdk/src/client/session_sigs.rs
@@ -17,7 +17,7 @@ impl<P: alloy::providers::Provider> super::LitNodeClient<P> {
         wallet: &PrivateKeySigner,
         resource_ability_requests: Vec<LitResourceAbilityRequest>,
         expiration: &str,
-        capacity_delegation_auth_sig: Option<AuthSig>,
+        capability_auth_sigs: Vec<AuthSig>,
     ) -> Result<SessionSignatures> {
         if !self.ready {
             return Err(eyre::eyre!("Lit Node Client not connected"));
@@ -51,9 +51,7 @@ impl<P: alloy::providers::Provider> super::LitNodeClient<P> {
             .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
 
         let mut capabilities = vec![auth_sig];
-        if let Some(capacity_auth_sig) = capacity_delegation_auth_sig {
-            capabilities.push(capacity_auth_sig);
-        }
+        capabilities.extend(capability_auth_sigs);
 
         for node_url in self.connected_nodes() {
             let session_key_signed_message = SessionKeySignedMessage {

--- a/lit-rust-sdk/tests/decrypt_client_side.rs
+++ b/lit-rust-sdk/tests/decrypt_client_side.rs
@@ -109,7 +109,7 @@ async fn test_client_side_decryption_with_session_sigs() {
 
     println!("🔄 Getting session signatures for decryption...");
     let session_sigs = client
-        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, None)
+        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, vec![])
         .await
         .expect("Failed to create local session signatures");
 
@@ -272,7 +272,7 @@ async fn test_client_side_decryption_with_session_sigs_and_evm_contract_conditio
 
     println!("🔄 Getting session signatures for decryption...");
     let session_sigs = client
-        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, None)
+        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, vec![])
         .await
         .expect("Failed to create local session signatures");
 

--- a/lit-rust-sdk/tests/decrypt_client_side_datil.rs
+++ b/lit-rust-sdk/tests/decrypt_client_side_datil.rs
@@ -182,7 +182,7 @@ async fn test_client_side_decryption_with_session_sigs() {
             &wallet,
             resource_ability_requests,
             &expiration,
-            Some(capacity_auth_sig),
+            vec![capacity_auth_sig],
         )
         .await
         .expect("Failed to create local session signatures");
@@ -416,7 +416,7 @@ async fn test_client_side_decryption_with_session_sigs_and_evm_contract_conditio
             &wallet,
             resource_ability_requests,
             &expiration,
-            Some(capacity_auth_sig),
+            vec![capacity_auth_sig],
         )
         .await
         .expect("Failed to create local session signatures");

--- a/lit-rust-sdk/tests/encrypt_test.rs
+++ b/lit-rust-sdk/tests/encrypt_test.rs
@@ -117,7 +117,7 @@ async fn test_encrypt_and_decrypt_with_session_sigs() {
 
     println!("🔄 Getting session signatures for decryption...");
     let session_sigs = client
-        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, None)
+        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, vec![])
         .await
         .expect("Failed to create local session signatures");
 

--- a/lit-rust-sdk/tests/local_session_sigs_test.rs
+++ b/lit-rust-sdk/tests/local_session_sigs_test.rs
@@ -65,7 +65,7 @@ async fn test_local_session_sigs_hello_world() {
 
     // Generate local session signatures without a PKP
     let session_sigs = client
-        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, None)
+        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, vec![])
         .await
         .expect("Failed to create local session signatures");
 
@@ -151,7 +151,7 @@ async fn test_local_session_sigs_with_params() {
 
     // Generate local session signatures without a PKP
     let session_sigs = client
-        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, None)
+        .get_local_session_sigs(&wallet, resource_ability_requests, &expiration, vec![])
         .await
         .expect("Failed to create local session signatures");
 


### PR DESCRIPTION
Add an additional parameter to support passing a Capacity Delegation AuthSig into the local session signature generation. I don't think the local generation otherwise supports `DatilTest` and `Datil`.

Added a test file as well.